### PR TITLE
Prevent rosapi failure

### DIFF
--- a/rosapi/src/rosapi/params.py
+++ b/rosapi/src/rosapi/params.py
@@ -224,12 +224,23 @@ def _get_param_names(node_name):
     global _parent_node_name
     if node_name == _parent_node_name:
         return []
-
+    
     client = _node.create_client(ListParameters, f"{node_name}/list_parameters")
 
-    ready = client.wait_for_service(timeout_sec=5.0)
+    ### Modified by Leidos 2022 to account for this issue https://github.com/RobotWebTools/rosbridge_suite/issues/756
+
+    ## Old logic
+    #ready = client.wait_for_service(timeout_sec=5.0)
+    #if not ready:
+    #    raise RuntimeError("Wait for list_parameters service timed out")
+
+    ## New logic
+    ready = client.wait_for_service(timeout_sec=0.1)
+
     if not ready:
-        raise RuntimeError("Wait for list_parameters service timed out")
+        return []
+
+    ### End modification
 
     request = ListParameters.Request()
     future = client.call_async(request)


### PR DESCRIPTION
This PR fixes and exception in the rosapi where calling the get_params service would try to get parameters from the component manager nodes which are special and don't have a list_parameters service. This fix makes the failing function return an empty parameter list in this case. 

Open issue on main line: https://github.com/RobotWebTools/rosbridge_suite/issues/756
Platform issue https://github.com/usdot-fhwa-stol/carma-platform/issues/1896